### PR TITLE
Ticket6041 add ioc measm905

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ relPaths.sh
 *_info_settings.req
 *.py[cod]
 __pycache__/
-/system_tests/test-reports
+test-reports

--- a/system_tests/lewis_emulators/Measm905/device.py
+++ b/system_tests/lewis_emulators/Measm905/device.py
@@ -12,7 +12,6 @@ class SimulatedMeasm905(StateMachineDevice):
         Initialize all of the device's attributes.
         """
         self.pressure = 1
-        self.test_thing = 47
 
     def _get_state_handlers(self):
         return {

--- a/system_tests/lewis_emulators/Measm905/device.py
+++ b/system_tests/lewis_emulators/Measm905/device.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from .states import DefaultState
 from lewis.devices import StateMachineDevice
-import random
 
 
 
@@ -12,7 +11,8 @@ class SimulatedMeasm905(StateMachineDevice):
         """
         Initialize all of the device's attributes.
         """
-        self._pressure = 1
+        self.pressure = 1
+        self.test_thing = 47
 
     def _get_state_handlers(self):
         return {
@@ -25,8 +25,4 @@ class SimulatedMeasm905(StateMachineDevice):
     def _get_transition_handlers(self):
         return OrderedDict([
         ])
-    
-    @property
-    def pressure(self):
-        return self._pressure
-    
+  

--- a/system_tests/tests/measm905.py
+++ b/system_tests/tests/measm905.py
@@ -33,6 +33,4 @@ class Measm905Tests(unittest.TestCase):
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_pressure_changes_THEN_pv_also_changes(self):
         self._lewis.backdoor_set_on_device("pressure", 42)
-        #self._lewis.backdoor_run_function_on_device("get_pressure")
-
         self.ca.assert_that_pv_is("PRESSURE", 42)

--- a/system_tests/tests/measm905.py
+++ b/system_tests/tests/measm905.py
@@ -19,7 +19,7 @@ IOCS = [
 ]
 
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM]
 
 
 class Measm905Tests(unittest.TestCase):
@@ -30,5 +30,9 @@ class Measm905Tests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("Measm905", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
-    def test_that_fails(self):
-        self.fail("You haven't implemented any tests!")
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_pressure_changes_THEN_pv_also_changes(self):
+        self._lewis.backdoor_set_on_device("pressure", 42)
+        #self._lewis.backdoor_run_function_on_device("get_pressure")
+
+        self.ca.assert_that_pv_is("PRESSURE", 42)


### PR DESCRIPTION
# Summary 

- Created IOC, OPI, lewis emulator for PEARL's Pressure Transducer, a MEASM905.
- Added manual to the isis\Shares


# Acceptance Criteria

- [ ] OPI is visible in Device Screens view
- [ ] Unit tests pass (just the one)
- [ ] OPI meets quality standards of OPIs
- [ ] IOC can communicate with physical device